### PR TITLE
Update test.yml to actions/upload-artifact@v4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       - run: gradle build publishToMavenLocal --stacktrace --warning-mode fail
         env:
           FORCE_PUBLISH: 1.19.4
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: Maven Local
           path: /root/.m2/repository


### PR DESCRIPTION
As discussed on the Fabric Discord server (`#toolchain-other`).

Bumping `actions/upload-artifact` to `v4` to prepare for the [deprecation of v3](https://github.blog/changelog/2024-11-05-notice-of-breaking-changes-for-github-actions/).